### PR TITLE
CP-9623 remove pastefromoffice

### DIFF
--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -44,7 +44,6 @@
     "@ckeditor/ckeditor5-list": "^35.3.0",
     "@ckeditor/ckeditor5-media-embed": "^35.3.0",
     "@ckeditor/ckeditor5-paragraph": "^35.3.0",
-    "@ckeditor/ckeditor5-paste-from-office": "^35.3.0",
     "@ckeditor/ckeditor5-special-characters": "^35.3.0",
     "@ckeditor/ckeditor5-style": "^35.3.0",
     "@ckeditor/ckeditor5-table": "^35.3.0",

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor5-custom-build",
-  "version": "35.3.3",
+  "version": "35.3.4",
   "description": "The classic editor build of CKEditor 5 – the best browser-based rich text editor.",
   "keywords": [
     "ckeditor5-build",

--- a/packages/ckeditor5-build-classic/src/ckeditor.js
+++ b/packages/ckeditor5-build-classic/src/ckeditor.js
@@ -28,7 +28,6 @@ import Link from '@ckeditor/ckeditor5-link/src/link';
 import List from '@ckeditor/ckeditor5-list/src/list';
 import MediaEmbed from '@ckeditor/ckeditor5-media-embed/src/mediaembed';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice';
 import Subscript from '@ckeditor/ckeditor5-basic-styles/src/subscript';
 import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
 import Table from '@ckeditor/ckeditor5-table/src/table';
@@ -65,7 +64,6 @@ const plugins = [
 	Underline,
 	MediaEmbed,
 	Paragraph,
-	PasteFromOffice,
 	SpecialCharacters,
 	Style,
 	Subscript,


### PR DESCRIPTION
Remove paste from office, as it just tries to preserve as much of the word markup as possible through styles and preserving word specific tags