### PR TITLE
IB-536 remove plank

### DIFF
--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ckeditor5-custom-build-no-plank",
+  "name": "ckeditor5-custom-build",
   "version": "41.3.1",
   "description": "The classic editor build of CKEditor 5 – the best browser-based rich text editor.",
   "keywords": [

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ckeditor5-custom-build",
+  "name": "ckeditor5-custom-build-no-plank",
   "version": "41.3.1",
   "description": "The classic editor build of CKEditor 5 – the best browser-based rich text editor.",
   "keywords": [

--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -11,7 +11,6 @@ import type { Editor, UiConfig } from '@ckeditor/ckeditor5-core';
 import {
 	DomEmitterMixin,
 	Rect,
-	verifyLicense,
 	type PositionOptions,
 	type Locale
 } from '@ckeditor/ckeditor5-utils';
@@ -101,9 +100,8 @@ export default class PoweredBy extends DomEmitterMixin() {
 	private _handleEditorReady(): void {
 		const editor = this.editor;
 		const forceVisible = !!editor.config.get( 'ui.poweredBy.forceVisible' );
-
 		/* istanbul ignore next -- @preserve */
-		if ( !forceVisible && verifyLicense( editor.config.get( 'licenseKey' ) ) === 'VALID' ) {
+		if ( !forceVisible ) {
 			return;
 		}
 


### PR DESCRIPTION
Remove validation of license

Tested locally with updated package on grading-frontend - no plank:
![image](https://github.com/inspera/ckeditor5/assets/128397414/e3a754d3-9403-4f47-8ec7-103cc4ab8b13)

